### PR TITLE
Fix endAttach handling for internalRender

### DIFF
--- a/src/Render.js
+++ b/src/Render.js
@@ -119,10 +119,13 @@ export default class Render {
       this.setState(null);
       const { wire } = this._aux;
       wire.setTarget(port.wrapper);
+      const success = this.addWire(wire);
 
-      this.addWire(wire);
+      if (!success && this.internalRender) {
+        this.removeElement(this._aux['wire']._el);
+      }
 
-      delete this._aux['wire'];
+      this._aux['wire'] = null;
     }
   }
 

--- a/src/dom-handler.js
+++ b/src/dom-handler.js
@@ -45,7 +45,7 @@ export function registerEvents () {
       return null;
     }
 
-    if (target.type === 'port' && target.direction === 'out') {
+    if (target.type === 'port') {
       this.startAttach(target);
 
       const { wire } = this._aux;
@@ -95,16 +95,17 @@ export function registerEvents () {
 
     this.dragging = null;
 
-    if (target.type === 'port') {
-      this.endAttach(target);
-    }
-
     if (this.isState('attaching')) {
-      if (this.internalRender)
-        svg.removeChild(this._aux['wire']._el);
+      if (target.type === 'port') {
+        this.endAttach(target);
+      } else {
+        if (this.internalRender) {
+          this.removeElement(this._aux['wire']._el);
+        }
 
-      this.setState(null)
-      this._aux['wire'] = null;
+        this.setState(null)
+        this._aux['wire'] = null;
+      }
     }
 
     forceUpdate();


### PR DESCRIPTION
Fixes #30 
also removes the restriction to only init a connection starting from `out` ports